### PR TITLE
fix shots being cancelled after first miss

### DIFF
--- a/objects/player.gd
+++ b/objects/player.gd
@@ -217,7 +217,7 @@ func action_shoot():
 			
 			raycast.force_raycast_update()
 			
-			if !raycast.is_colliding(): return # Don't create impact when raycast didn't hit
+			if !raycast.is_colliding(): continue # Don't create impact when raycast didn't hit
 			
 			var collider = raycast.get_collider()
 			


### PR DESCRIPTION
fixed: if a weapon has multiple shots and e.g. the first raycast doesn't collide, then the whole loop is quit and the other raycasts aren't checked