### PR TITLE
Reduce Framerate Dependence

### DIFF
--- a/objects/player.gd
+++ b/objects/player.gd
@@ -1,7 +1,7 @@
 extends CharacterBody3D
 
 @export_subgroup("Properties")
-@export var movement_speed = 250
+@export var movement_speed = 5
 @export var jump_strength = 7
 
 @export_subgroup("Weapons")
@@ -130,7 +130,7 @@ func handle_controls(delta):
 	input.x = Input.get_axis("move_left", "move_right")
 	input.z = Input.get_axis("move_forward", "move_back")
 	
-	movement_velocity = input.normalized() * movement_speed * delta
+	movement_velocity = input.normalized() * movement_speed
 	
 	# Rotation
 	
@@ -139,7 +139,7 @@ func handle_controls(delta):
 	rotation_input.y = Input.get_axis("camera_left", "camera_right")
 	rotation_input.x = Input.get_axis("camera_up", "camera_down") / 2
 	
-	rotation_target -= rotation_input.limit_length(1.0) * 5 * delta
+	rotation_target -= rotation_input.limit_length(1.0) * 5
 	rotation_target.x = clamp(rotation_target.x, deg_to_rad(-90), deg_to_rad(90))
 	
 	# Shooting


### PR DESCRIPTION
I noticed when testing out this starter kit that my movement speed was noticeably slower than the example video I saw on reddit and mastadon. I have a high refresh rate monitor (165Hz), so I suspected that was the cause. Taking a look at the code, it seems that the main culprit was that the target movement speed is being multiplied by the frame delta, causing the player's max movement speed to scale linearly with the frame duration. This is a case where delta *shouldn't* be used, as what's being adjusted has nothing to do with how long a frame takes to render. I similarly removed the multiplication by delta for the camera rotation in the same function, since that appears to be making the same mistake.

I know this isn't *everything* to get perfect framerate independence (notably, I'm very confident that the use of lerp in the update function is incorrect), but this is enough to make this starter kit **playable** on high refresh rate monitors.