### PR TITLE
Add Particle Effect on Enemy Destruction

### DIFF
--- a/objects/enemy.gd
+++ b/objects/enemy.gd
@@ -1,6 +1,7 @@
 extends Node3D
 
 @export var player:Node3D
+@export var explosion:PackedScene = preload("res://objects/explosion.tscn")
 
 @onready var raycast = $RayCast
 @onready var muzzle_a = $MuzzleA
@@ -42,6 +43,9 @@ func damage(amount):
 func destroy():
 	
 	Audio.play("sounds/enemy_destroy.ogg")
+	var effects = explosion.instantiate()
+	effects.transform = transform
+	get_parent().add_child(effects)
 	
 	destroyed = true
 	queue_free()

--- a/objects/explosion.tscn
+++ b/objects/explosion.tscn
@@ -1,0 +1,52 @@
+[gd_scene load_steps=8 format=3 uid="uid://b12upspnoxxag"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_7mj45"]
+transparency = 1
+vertex_color_use_as_albedo = true
+
+[sub_resource type="Gradient" id="Gradient_5nod5"]
+offsets = PackedFloat32Array(0, 0.5, 1)
+colors = PackedColorArray(0, 0, 0, 1, 0.3, 0.15, 0.15, 1, 0.6, 0.6, 0.6, 1)
+
+[sub_resource type="GradientTexture1D" id="GradientTexture1D_fr1au"]
+gradient = SubResource("Gradient_5nod5")
+
+[sub_resource type="Gradient" id="Gradient_i8smv"]
+offsets = PackedFloat32Array(0, 0.8, 1)
+colors = PackedColorArray(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0)
+
+[sub_resource type="GradientTexture1D" id="GradientTexture1D_861rp"]
+gradient = SubResource("Gradient_i8smv")
+
+[sub_resource type="ParticleProcessMaterial" id="ParticleProcessMaterial_mmndt"]
+lifetime_randomness = 0.25
+emission_shape = 1
+emission_sphere_radius = 0.25
+direction = Vector3(0, 1, 0)
+spread = 35.0
+initial_velocity_min = 1.0
+initial_velocity_max = 4.0
+scale_min = 0.8
+color_ramp = SubResource("GradientTexture1D_861rp")
+color_initial_ramp = SubResource("GradientTexture1D_fr1au")
+
+[sub_resource type="BoxMesh" id="BoxMesh_oe02q"]
+size = Vector3(0.1, 0.1, 0.1)
+
+[node name="explosion" type="Node3D"]
+
+[node name="GPUParticles3D" type="GPUParticles3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
+material_override = SubResource("StandardMaterial3D_7mj45")
+amount = 64
+lifetime = 0.8
+one_shot = true
+explosiveness = 1.0
+process_material = SubResource("ParticleProcessMaterial_mmndt")
+draw_pass_1 = SubResource("BoxMesh_oe02q")
+
+[node name="Timer" type="Timer" parent="."]
+one_shot = true
+autostart = true
+
+[connection signal="timeout" from="Timer" to="." method="queue_free"]


### PR DESCRIPTION
I had [left a comment on reddit](https://www.reddit.com/r/godot/comments/16xxch1/created_a_first_person_shooter_example_for_godot/k38515p/) suggesting adding a particle effect when an enemy is destroyed to give the demo a little more impact. This is my (fairly rushed) attempt at implementing something for that. This PR adds an explosion.tscn with a simple particle effect I made and a timer to remove the particle spawner once it's no longer needed. I also updated the enemy script to add the explosion to the scene at the enemy's position when it's destroyed.

The particle effect I made for this is really simplistic, and I'm not sure it's at the same quality as the starter kit as a whole, so I would understand not merging this as-is. I wanted to make the PR for it, though, to have a place for discussion as well as see if there's any ideas to improve it. Right now the particles themselves are very simplistic, just being colored cubes. The mesh and material could be swapped out for something better, and the choice of colors could maybe be improved (I'm colorblind, so I wasn't sure about the best choice of colors). Feel free to mess with this in the editor, but do note that because of https://github.com/godotengine/godot/issues/17903 you'll need to make sure you re-enable `emitting` before saving the scene.