### PR TITLE
Change weapon sway from global motion to local

### DIFF
--- a/objects/player.gd
+++ b/objects/player.gd
@@ -76,7 +76,7 @@ func _physics_process(delta):
 	camera.rotation.x = lerp_angle(camera.rotation.x, rotation_target.x, delta * 25)
 	rotation.y = lerp_angle(rotation.y, rotation_target.y, delta * 25)
 	
-	container.position = lerp(container.position, container_offset - (applied_velocity / 30), delta * 10)
+	container.position = lerp(container.position, container_offset - (basis.inverse() * applied_velocity / 30), delta * 10)
 	
 	# Movement sound
 	


### PR DESCRIPTION
(This kit is bonkers cool 😍 )

When turning the camera left or right, the weapon sway was fixed in a global direction, so when moving forwards and back while looking in the +x direction, the weapon would sway left and right.

Beefed it out and multiplying by the inverse of the player's basis turns that global force into a local direction, so the weapon sway rotates with the player ^^