### PR TITLE
Make ceiling cancel jump velocity

### DIFF
--- a/objects/player.gd
+++ b/objects/player.gd
@@ -154,6 +154,9 @@ func handle_rotation(xRot: float, yRot: float, isController: bool, delta: float 
 
 func handle_gravity(delta):
 	gravity += 20 * delta
+
+	if gravity < 0 and is_on_ceiling():
+		gravity = 0
 	
 	if gravity > 0 and is_on_floor():
 		jumps_remaining = number_of_jumps


### PR DESCRIPTION
Right now, if you jump and hit a ceiling, your character will awkwardly keep floating in the air for a few seconds.

https://github.com/user-attachments/assets/fbf767cf-7e31-4ce3-8def-3d5239786238


The problem is that it takes a while for normal gravity to cancel out all the negative gravity given by the jump.

With this fix, gravity is set to 0 if you hit a ceiling while having negative gravity.

https://github.com/user-attachments/assets/2c148e6d-cef2-4314-9020-995fa6d27ba4


